### PR TITLE
`main` and `exports` adjustments

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "url": "https://code.forcir.com"
     },
     "type": "module",
-    "main": "dist/index",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "files": [
         "dist"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,18 @@
     },
     "type": "module",
     "main": "dist/index.js",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./dist/index.d.ts",
+                "default": "./dist/index.js"
+            },
+            "require": {
+                "types": "./dist/index.d.cts",
+                "default": "./dist/index.cjs"
+            }
+        }
+    },
     "types": "dist/index.d.ts",
     "files": [
         "dist"


### PR DESCRIPTION
Hi,

Thanks for your project! Looks like it should be handy for us...

Two related commits here:

- fix: add extension to main entry point to 'dist/index.js'
- feat: add exports field for module and commonjs support

The first commit addresses the following bug:

<img width="1359" height="72" alt="image" src="https://github.com/user-attachments/assets/d7a96e8b-e7c5-424d-89cb-c3e0787d2fee" />

The second commit allows discovery for CJS environments.