### PR TITLE
Release 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "object-deep-merge",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "private": false,
     "description": "Strongly-typed deep and recursive object merging. Considers all nested levels of objects, arrays, sets and maps.",
     "keywords": [


### PR DESCRIPTION
Bumps object-deep-merge to 2.0.1 for the merged prototype-pollution fix in #49.